### PR TITLE
remove tacho % text, because already included in tacho_percent_back.svg

### DIFF
--- a/themes/bright/skinparts/tachohands/perc_0.svg
+++ b/themes/bright/skinparts/tachohands/perc_0.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_1.svg
+++ b/themes/bright/skinparts/tachohands/perc_1.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_10.svg
+++ b/themes/bright/skinparts/tachohands/perc_10.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_100.svg
+++ b/themes/bright/skinparts/tachohands/perc_100.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_11.svg
+++ b/themes/bright/skinparts/tachohands/perc_11.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_12.svg
+++ b/themes/bright/skinparts/tachohands/perc_12.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_13.svg
+++ b/themes/bright/skinparts/tachohands/perc_13.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_14.svg
+++ b/themes/bright/skinparts/tachohands/perc_14.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_15.svg
+++ b/themes/bright/skinparts/tachohands/perc_15.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_16.svg
+++ b/themes/bright/skinparts/tachohands/perc_16.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_17.svg
+++ b/themes/bright/skinparts/tachohands/perc_17.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_18.svg
+++ b/themes/bright/skinparts/tachohands/perc_18.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_19.svg
+++ b/themes/bright/skinparts/tachohands/perc_19.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_2.svg
+++ b/themes/bright/skinparts/tachohands/perc_2.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_20.svg
+++ b/themes/bright/skinparts/tachohands/perc_20.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_21.svg
+++ b/themes/bright/skinparts/tachohands/perc_21.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_22.svg
+++ b/themes/bright/skinparts/tachohands/perc_22.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_23.svg
+++ b/themes/bright/skinparts/tachohands/perc_23.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_24.svg
+++ b/themes/bright/skinparts/tachohands/perc_24.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_25.svg
+++ b/themes/bright/skinparts/tachohands/perc_25.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_26.svg
+++ b/themes/bright/skinparts/tachohands/perc_26.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_27.svg
+++ b/themes/bright/skinparts/tachohands/perc_27.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_28.svg
+++ b/themes/bright/skinparts/tachohands/perc_28.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_29.svg
+++ b/themes/bright/skinparts/tachohands/perc_29.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_3.svg
+++ b/themes/bright/skinparts/tachohands/perc_3.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_30.svg
+++ b/themes/bright/skinparts/tachohands/perc_30.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_31.svg
+++ b/themes/bright/skinparts/tachohands/perc_31.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_32.svg
+++ b/themes/bright/skinparts/tachohands/perc_32.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_33.svg
+++ b/themes/bright/skinparts/tachohands/perc_33.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_34.svg
+++ b/themes/bright/skinparts/tachohands/perc_34.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_35.svg
+++ b/themes/bright/skinparts/tachohands/perc_35.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_36.svg
+++ b/themes/bright/skinparts/tachohands/perc_36.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_37.svg
+++ b/themes/bright/skinparts/tachohands/perc_37.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_38.svg
+++ b/themes/bright/skinparts/tachohands/perc_38.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_39.svg
+++ b/themes/bright/skinparts/tachohands/perc_39.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_4.svg
+++ b/themes/bright/skinparts/tachohands/perc_4.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_40.svg
+++ b/themes/bright/skinparts/tachohands/perc_40.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_41.svg
+++ b/themes/bright/skinparts/tachohands/perc_41.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_42.svg
+++ b/themes/bright/skinparts/tachohands/perc_42.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_43.svg
+++ b/themes/bright/skinparts/tachohands/perc_43.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_44.svg
+++ b/themes/bright/skinparts/tachohands/perc_44.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_45.svg
+++ b/themes/bright/skinparts/tachohands/perc_45.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_46.svg
+++ b/themes/bright/skinparts/tachohands/perc_46.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_47.svg
+++ b/themes/bright/skinparts/tachohands/perc_47.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_48.svg
+++ b/themes/bright/skinparts/tachohands/perc_48.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_49.svg
+++ b/themes/bright/skinparts/tachohands/perc_49.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_5.svg
+++ b/themes/bright/skinparts/tachohands/perc_5.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_50.svg
+++ b/themes/bright/skinparts/tachohands/perc_50.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_51.svg
+++ b/themes/bright/skinparts/tachohands/perc_51.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_52.svg
+++ b/themes/bright/skinparts/tachohands/perc_52.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_53.svg
+++ b/themes/bright/skinparts/tachohands/perc_53.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_54.svg
+++ b/themes/bright/skinparts/tachohands/perc_54.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_55.svg
+++ b/themes/bright/skinparts/tachohands/perc_55.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_56.svg
+++ b/themes/bright/skinparts/tachohands/perc_56.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_57.svg
+++ b/themes/bright/skinparts/tachohands/perc_57.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_58.svg
+++ b/themes/bright/skinparts/tachohands/perc_58.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_59.svg
+++ b/themes/bright/skinparts/tachohands/perc_59.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_6.svg
+++ b/themes/bright/skinparts/tachohands/perc_6.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_60.svg
+++ b/themes/bright/skinparts/tachohands/perc_60.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_61.svg
+++ b/themes/bright/skinparts/tachohands/perc_61.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_62.svg
+++ b/themes/bright/skinparts/tachohands/perc_62.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_63.svg
+++ b/themes/bright/skinparts/tachohands/perc_63.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_64.svg
+++ b/themes/bright/skinparts/tachohands/perc_64.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_65.svg
+++ b/themes/bright/skinparts/tachohands/perc_65.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_66.svg
+++ b/themes/bright/skinparts/tachohands/perc_66.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_67.svg
+++ b/themes/bright/skinparts/tachohands/perc_67.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_68.svg
+++ b/themes/bright/skinparts/tachohands/perc_68.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_69.svg
+++ b/themes/bright/skinparts/tachohands/perc_69.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_7.svg
+++ b/themes/bright/skinparts/tachohands/perc_7.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_70.svg
+++ b/themes/bright/skinparts/tachohands/perc_70.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_71.svg
+++ b/themes/bright/skinparts/tachohands/perc_71.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_72.svg
+++ b/themes/bright/skinparts/tachohands/perc_72.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_73.svg
+++ b/themes/bright/skinparts/tachohands/perc_73.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_74.svg
+++ b/themes/bright/skinparts/tachohands/perc_74.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_75.svg
+++ b/themes/bright/skinparts/tachohands/perc_75.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_76.svg
+++ b/themes/bright/skinparts/tachohands/perc_76.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_77.svg
+++ b/themes/bright/skinparts/tachohands/perc_77.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_78.svg
+++ b/themes/bright/skinparts/tachohands/perc_78.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_79.svg
+++ b/themes/bright/skinparts/tachohands/perc_79.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_8.svg
+++ b/themes/bright/skinparts/tachohands/perc_8.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_80.svg
+++ b/themes/bright/skinparts/tachohands/perc_80.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_81.svg
+++ b/themes/bright/skinparts/tachohands/perc_81.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_82.svg
+++ b/themes/bright/skinparts/tachohands/perc_82.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_83.svg
+++ b/themes/bright/skinparts/tachohands/perc_83.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_84.svg
+++ b/themes/bright/skinparts/tachohands/perc_84.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_85.svg
+++ b/themes/bright/skinparts/tachohands/perc_85.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_86.svg
+++ b/themes/bright/skinparts/tachohands/perc_86.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_87.svg
+++ b/themes/bright/skinparts/tachohands/perc_87.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_88.svg
+++ b/themes/bright/skinparts/tachohands/perc_88.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_89.svg
+++ b/themes/bright/skinparts/tachohands/perc_89.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_9.svg
+++ b/themes/bright/skinparts/tachohands/perc_9.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_90.svg
+++ b/themes/bright/skinparts/tachohands/perc_90.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_91.svg
+++ b/themes/bright/skinparts/tachohands/perc_91.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_92.svg
+++ b/themes/bright/skinparts/tachohands/perc_92.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_93.svg
+++ b/themes/bright/skinparts/tachohands/perc_93.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_94.svg
+++ b/themes/bright/skinparts/tachohands/perc_94.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_95.svg
+++ b/themes/bright/skinparts/tachohands/perc_95.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_96.svg
+++ b/themes/bright/skinparts/tachohands/perc_96.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_97.svg
+++ b/themes/bright/skinparts/tachohands/perc_97.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_98.svg
+++ b/themes/bright/skinparts/tachohands/perc_98.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/bright/skinparts/tachohands/perc_99.svg
+++ b/themes/bright/skinparts/tachohands/perc_99.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_0.svg
+++ b/themes/dark/skinparts/tachohands/perc_0.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_1.svg
+++ b/themes/dark/skinparts/tachohands/perc_1.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_10.svg
+++ b/themes/dark/skinparts/tachohands/perc_10.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_100.svg
+++ b/themes/dark/skinparts/tachohands/perc_100.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_11.svg
+++ b/themes/dark/skinparts/tachohands/perc_11.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_12.svg
+++ b/themes/dark/skinparts/tachohands/perc_12.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_13.svg
+++ b/themes/dark/skinparts/tachohands/perc_13.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_14.svg
+++ b/themes/dark/skinparts/tachohands/perc_14.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_15.svg
+++ b/themes/dark/skinparts/tachohands/perc_15.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_16.svg
+++ b/themes/dark/skinparts/tachohands/perc_16.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_17.svg
+++ b/themes/dark/skinparts/tachohands/perc_17.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_18.svg
+++ b/themes/dark/skinparts/tachohands/perc_18.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_19.svg
+++ b/themes/dark/skinparts/tachohands/perc_19.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_2.svg
+++ b/themes/dark/skinparts/tachohands/perc_2.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_20.svg
+++ b/themes/dark/skinparts/tachohands/perc_20.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_21.svg
+++ b/themes/dark/skinparts/tachohands/perc_21.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_22.svg
+++ b/themes/dark/skinparts/tachohands/perc_22.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_23.svg
+++ b/themes/dark/skinparts/tachohands/perc_23.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_24.svg
+++ b/themes/dark/skinparts/tachohands/perc_24.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_25.svg
+++ b/themes/dark/skinparts/tachohands/perc_25.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_26.svg
+++ b/themes/dark/skinparts/tachohands/perc_26.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_27.svg
+++ b/themes/dark/skinparts/tachohands/perc_27.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_28.svg
+++ b/themes/dark/skinparts/tachohands/perc_28.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_29.svg
+++ b/themes/dark/skinparts/tachohands/perc_29.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_3.svg
+++ b/themes/dark/skinparts/tachohands/perc_3.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_30.svg
+++ b/themes/dark/skinparts/tachohands/perc_30.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_31.svg
+++ b/themes/dark/skinparts/tachohands/perc_31.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_32.svg
+++ b/themes/dark/skinparts/tachohands/perc_32.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_33.svg
+++ b/themes/dark/skinparts/tachohands/perc_33.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_34.svg
+++ b/themes/dark/skinparts/tachohands/perc_34.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_35.svg
+++ b/themes/dark/skinparts/tachohands/perc_35.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_36.svg
+++ b/themes/dark/skinparts/tachohands/perc_36.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_37.svg
+++ b/themes/dark/skinparts/tachohands/perc_37.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_38.svg
+++ b/themes/dark/skinparts/tachohands/perc_38.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_39.svg
+++ b/themes/dark/skinparts/tachohands/perc_39.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_4.svg
+++ b/themes/dark/skinparts/tachohands/perc_4.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_40.svg
+++ b/themes/dark/skinparts/tachohands/perc_40.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_41.svg
+++ b/themes/dark/skinparts/tachohands/perc_41.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_42.svg
+++ b/themes/dark/skinparts/tachohands/perc_42.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_43.svg
+++ b/themes/dark/skinparts/tachohands/perc_43.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_44.svg
+++ b/themes/dark/skinparts/tachohands/perc_44.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_45.svg
+++ b/themes/dark/skinparts/tachohands/perc_45.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_46.svg
+++ b/themes/dark/skinparts/tachohands/perc_46.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_47.svg
+++ b/themes/dark/skinparts/tachohands/perc_47.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_48.svg
+++ b/themes/dark/skinparts/tachohands/perc_48.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_49.svg
+++ b/themes/dark/skinparts/tachohands/perc_49.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_5.svg
+++ b/themes/dark/skinparts/tachohands/perc_5.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_50.svg
+++ b/themes/dark/skinparts/tachohands/perc_50.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_51.svg
+++ b/themes/dark/skinparts/tachohands/perc_51.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_52.svg
+++ b/themes/dark/skinparts/tachohands/perc_52.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_53.svg
+++ b/themes/dark/skinparts/tachohands/perc_53.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_54.svg
+++ b/themes/dark/skinparts/tachohands/perc_54.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_55.svg
+++ b/themes/dark/skinparts/tachohands/perc_55.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_56.svg
+++ b/themes/dark/skinparts/tachohands/perc_56.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_57.svg
+++ b/themes/dark/skinparts/tachohands/perc_57.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_58.svg
+++ b/themes/dark/skinparts/tachohands/perc_58.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_59.svg
+++ b/themes/dark/skinparts/tachohands/perc_59.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_6.svg
+++ b/themes/dark/skinparts/tachohands/perc_6.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_60.svg
+++ b/themes/dark/skinparts/tachohands/perc_60.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_61.svg
+++ b/themes/dark/skinparts/tachohands/perc_61.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_62.svg
+++ b/themes/dark/skinparts/tachohands/perc_62.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_63.svg
+++ b/themes/dark/skinparts/tachohands/perc_63.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_64.svg
+++ b/themes/dark/skinparts/tachohands/perc_64.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_65.svg
+++ b/themes/dark/skinparts/tachohands/perc_65.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_66.svg
+++ b/themes/dark/skinparts/tachohands/perc_66.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_67.svg
+++ b/themes/dark/skinparts/tachohands/perc_67.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_68.svg
+++ b/themes/dark/skinparts/tachohands/perc_68.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_69.svg
+++ b/themes/dark/skinparts/tachohands/perc_69.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_7.svg
+++ b/themes/dark/skinparts/tachohands/perc_7.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_70.svg
+++ b/themes/dark/skinparts/tachohands/perc_70.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_71.svg
+++ b/themes/dark/skinparts/tachohands/perc_71.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_72.svg
+++ b/themes/dark/skinparts/tachohands/perc_72.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_73.svg
+++ b/themes/dark/skinparts/tachohands/perc_73.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_74.svg
+++ b/themes/dark/skinparts/tachohands/perc_74.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_75.svg
+++ b/themes/dark/skinparts/tachohands/perc_75.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_76.svg
+++ b/themes/dark/skinparts/tachohands/perc_76.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_77.svg
+++ b/themes/dark/skinparts/tachohands/perc_77.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_78.svg
+++ b/themes/dark/skinparts/tachohands/perc_78.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_79.svg
+++ b/themes/dark/skinparts/tachohands/perc_79.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_8.svg
+++ b/themes/dark/skinparts/tachohands/perc_8.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_80.svg
+++ b/themes/dark/skinparts/tachohands/perc_80.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_81.svg
+++ b/themes/dark/skinparts/tachohands/perc_81.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_82.svg
+++ b/themes/dark/skinparts/tachohands/perc_82.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_83.svg
+++ b/themes/dark/skinparts/tachohands/perc_83.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_84.svg
+++ b/themes/dark/skinparts/tachohands/perc_84.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_85.svg
+++ b/themes/dark/skinparts/tachohands/perc_85.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_86.svg
+++ b/themes/dark/skinparts/tachohands/perc_86.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_87.svg
+++ b/themes/dark/skinparts/tachohands/perc_87.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_88.svg
+++ b/themes/dark/skinparts/tachohands/perc_88.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_89.svg
+++ b/themes/dark/skinparts/tachohands/perc_89.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_9.svg
+++ b/themes/dark/skinparts/tachohands/perc_9.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_90.svg
+++ b/themes/dark/skinparts/tachohands/perc_90.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_91.svg
+++ b/themes/dark/skinparts/tachohands/perc_91.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_92.svg
+++ b/themes/dark/skinparts/tachohands/perc_92.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_93.svg
+++ b/themes/dark/skinparts/tachohands/perc_93.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_94.svg
+++ b/themes/dark/skinparts/tachohands/perc_94.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_95.svg
+++ b/themes/dark/skinparts/tachohands/perc_95.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_96.svg
+++ b/themes/dark/skinparts/tachohands/perc_96.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_97.svg
+++ b/themes/dark/skinparts/tachohands/perc_97.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_98.svg
+++ b/themes/dark/skinparts/tachohands/perc_98.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/dark/skinparts/tachohands/perc_99.svg
+++ b/themes/dark/skinparts/tachohands/perc_99.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_0.svg
+++ b/themes/default/skinparts/tachohands/perc_0.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_1.svg
+++ b/themes/default/skinparts/tachohands/perc_1.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_10.svg
+++ b/themes/default/skinparts/tachohands/perc_10.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_100.svg
+++ b/themes/default/skinparts/tachohands/perc_100.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_11.svg
+++ b/themes/default/skinparts/tachohands/perc_11.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_12.svg
+++ b/themes/default/skinparts/tachohands/perc_12.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_13.svg
+++ b/themes/default/skinparts/tachohands/perc_13.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_14.svg
+++ b/themes/default/skinparts/tachohands/perc_14.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_15.svg
+++ b/themes/default/skinparts/tachohands/perc_15.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_16.svg
+++ b/themes/default/skinparts/tachohands/perc_16.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_17.svg
+++ b/themes/default/skinparts/tachohands/perc_17.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_18.svg
+++ b/themes/default/skinparts/tachohands/perc_18.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_19.svg
+++ b/themes/default/skinparts/tachohands/perc_19.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_2.svg
+++ b/themes/default/skinparts/tachohands/perc_2.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_20.svg
+++ b/themes/default/skinparts/tachohands/perc_20.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_21.svg
+++ b/themes/default/skinparts/tachohands/perc_21.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_22.svg
+++ b/themes/default/skinparts/tachohands/perc_22.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_23.svg
+++ b/themes/default/skinparts/tachohands/perc_23.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_24.svg
+++ b/themes/default/skinparts/tachohands/perc_24.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_25.svg
+++ b/themes/default/skinparts/tachohands/perc_25.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_26.svg
+++ b/themes/default/skinparts/tachohands/perc_26.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_27.svg
+++ b/themes/default/skinparts/tachohands/perc_27.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_28.svg
+++ b/themes/default/skinparts/tachohands/perc_28.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_29.svg
+++ b/themes/default/skinparts/tachohands/perc_29.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_3.svg
+++ b/themes/default/skinparts/tachohands/perc_3.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_30.svg
+++ b/themes/default/skinparts/tachohands/perc_30.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_31.svg
+++ b/themes/default/skinparts/tachohands/perc_31.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_32.svg
+++ b/themes/default/skinparts/tachohands/perc_32.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_33.svg
+++ b/themes/default/skinparts/tachohands/perc_33.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_34.svg
+++ b/themes/default/skinparts/tachohands/perc_34.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_35.svg
+++ b/themes/default/skinparts/tachohands/perc_35.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_36.svg
+++ b/themes/default/skinparts/tachohands/perc_36.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_37.svg
+++ b/themes/default/skinparts/tachohands/perc_37.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_38.svg
+++ b/themes/default/skinparts/tachohands/perc_38.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_39.svg
+++ b/themes/default/skinparts/tachohands/perc_39.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_4.svg
+++ b/themes/default/skinparts/tachohands/perc_4.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_40.svg
+++ b/themes/default/skinparts/tachohands/perc_40.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_41.svg
+++ b/themes/default/skinparts/tachohands/perc_41.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_42.svg
+++ b/themes/default/skinparts/tachohands/perc_42.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_43.svg
+++ b/themes/default/skinparts/tachohands/perc_43.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_44.svg
+++ b/themes/default/skinparts/tachohands/perc_44.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_45.svg
+++ b/themes/default/skinparts/tachohands/perc_45.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_46.svg
+++ b/themes/default/skinparts/tachohands/perc_46.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_47.svg
+++ b/themes/default/skinparts/tachohands/perc_47.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_48.svg
+++ b/themes/default/skinparts/tachohands/perc_48.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_49.svg
+++ b/themes/default/skinparts/tachohands/perc_49.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_5.svg
+++ b/themes/default/skinparts/tachohands/perc_5.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_50.svg
+++ b/themes/default/skinparts/tachohands/perc_50.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_51.svg
+++ b/themes/default/skinparts/tachohands/perc_51.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_52.svg
+++ b/themes/default/skinparts/tachohands/perc_52.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_53.svg
+++ b/themes/default/skinparts/tachohands/perc_53.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_54.svg
+++ b/themes/default/skinparts/tachohands/perc_54.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_55.svg
+++ b/themes/default/skinparts/tachohands/perc_55.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_56.svg
+++ b/themes/default/skinparts/tachohands/perc_56.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_57.svg
+++ b/themes/default/skinparts/tachohands/perc_57.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_58.svg
+++ b/themes/default/skinparts/tachohands/perc_58.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_59.svg
+++ b/themes/default/skinparts/tachohands/perc_59.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_6.svg
+++ b/themes/default/skinparts/tachohands/perc_6.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_60.svg
+++ b/themes/default/skinparts/tachohands/perc_60.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_61.svg
+++ b/themes/default/skinparts/tachohands/perc_61.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_62.svg
+++ b/themes/default/skinparts/tachohands/perc_62.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_63.svg
+++ b/themes/default/skinparts/tachohands/perc_63.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_64.svg
+++ b/themes/default/skinparts/tachohands/perc_64.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_65.svg
+++ b/themes/default/skinparts/tachohands/perc_65.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_66.svg
+++ b/themes/default/skinparts/tachohands/perc_66.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_67.svg
+++ b/themes/default/skinparts/tachohands/perc_67.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_68.svg
+++ b/themes/default/skinparts/tachohands/perc_68.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_69.svg
+++ b/themes/default/skinparts/tachohands/perc_69.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_7.svg
+++ b/themes/default/skinparts/tachohands/perc_7.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_70.svg
+++ b/themes/default/skinparts/tachohands/perc_70.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_71.svg
+++ b/themes/default/skinparts/tachohands/perc_71.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_72.svg
+++ b/themes/default/skinparts/tachohands/perc_72.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_73.svg
+++ b/themes/default/skinparts/tachohands/perc_73.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_74.svg
+++ b/themes/default/skinparts/tachohands/perc_74.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_75.svg
+++ b/themes/default/skinparts/tachohands/perc_75.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_76.svg
+++ b/themes/default/skinparts/tachohands/perc_76.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_77.svg
+++ b/themes/default/skinparts/tachohands/perc_77.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_78.svg
+++ b/themes/default/skinparts/tachohands/perc_78.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_79.svg
+++ b/themes/default/skinparts/tachohands/perc_79.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_8.svg
+++ b/themes/default/skinparts/tachohands/perc_8.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_80.svg
+++ b/themes/default/skinparts/tachohands/perc_80.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_81.svg
+++ b/themes/default/skinparts/tachohands/perc_81.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_82.svg
+++ b/themes/default/skinparts/tachohands/perc_82.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_83.svg
+++ b/themes/default/skinparts/tachohands/perc_83.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_84.svg
+++ b/themes/default/skinparts/tachohands/perc_84.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_85.svg
+++ b/themes/default/skinparts/tachohands/perc_85.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_86.svg
+++ b/themes/default/skinparts/tachohands/perc_86.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_87.svg
+++ b/themes/default/skinparts/tachohands/perc_87.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_88.svg
+++ b/themes/default/skinparts/tachohands/perc_88.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_89.svg
+++ b/themes/default/skinparts/tachohands/perc_89.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_9.svg
+++ b/themes/default/skinparts/tachohands/perc_9.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_90.svg
+++ b/themes/default/skinparts/tachohands/perc_90.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_91.svg
+++ b/themes/default/skinparts/tachohands/perc_91.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_92.svg
+++ b/themes/default/skinparts/tachohands/perc_92.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_93.svg
+++ b/themes/default/skinparts/tachohands/perc_93.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_94.svg
+++ b/themes/default/skinparts/tachohands/perc_94.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_95.svg
+++ b/themes/default/skinparts/tachohands/perc_95.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_96.svg
+++ b/themes/default/skinparts/tachohands/perc_96.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_97.svg
+++ b/themes/default/skinparts/tachohands/perc_97.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_98.svg
+++ b/themes/default/skinparts/tachohands/perc_98.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>

--- a/themes/default/skinparts/tachohands/perc_99.svg
+++ b/themes/default/skinparts/tachohands/perc_99.svg
@@ -78,17 +78,5 @@
          d="m 65.000024,119.99999 10,26 10,-26 z"
          style="fill:#d40000;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="89.047386"
-       y="134.77823"
-       id="text6300"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         id="tspan6302"
-         x="89.047386"
-         y="134.77823"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:30px;line-height:125%;font-family:DS-Digital;-inkscape-font-specification:'DS-Digital, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff">%</tspan></text>
   </g>
 </svg>


### PR DESCRIPTION
remove the text based % sign because it's already included in the drawing